### PR TITLE
Suggested fix for mimosa command processing on Windows

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,5 +1,3 @@
-{exec} = require 'child_process'
-
 program =  require 'commander'
 
 version =  require('../package.json').version
@@ -8,7 +6,7 @@ logger =   require './util/logger'
 class Mimosa
 
   constructor: ->
-    return @printHelp() if process.argv.length is 2
+    process.argv[2] = '--help' if process.argv.length is 2
 
     program.version(version)
     require('./command/new')(program)
@@ -19,13 +17,11 @@ class Mimosa
     require('./command/virgin')(program)
     require('./command/update')(program)
     require('./command/install')(program)
-    program.command('*').action @printHelp
+    program.command('*').action (arg) ->
+      if arg then logger.red "  #{arg} is not a valid command."
+      process.argv[2] = '--help'
+      program.parse process.argv
 
     program.parse process.argv
-
-  printHelp: (arg) ->
-    exec "mimosa --help", (error, stdout, stderr) ->
-      if arg then logger.red "\n  #{arg} is not a valid command."
-      logger.green stdout
 
 module.exports = new Mimosa()


### PR DESCRIPTION
1) Typing `mimosa` at the command line did not output anything. The expected behavior was for it to default to `mimosa --help`.
2) Typing `mimosa <invalid_command>` only showed an invalid command error message instead of both the error message and the usage info.

This fix involves updating the process arguments rather than running mimosa again using `exec "mimosa --help"`, which does not seem to work properly on Windows.
