### PR TITLE
Use code from special region in configuration file to precompile config

### DIFF
--- a/lib/util/util.coffee
+++ b/lib/util/util.coffee
@@ -1,5 +1,6 @@
 path   = require 'path'
 fs     = require 'fs'
+Module = require 'module'
 
 color  = require('ansi-color').set
 logger = require 'logmimosa'
@@ -42,8 +43,11 @@ exports.requireConfig = requireConfig = (configPath) ->
         if err instanceof SyntaxError
           err.message = "[precompile region] " + err.message
         throw err
-    configModule = new (require "module") configPath
+    configModule = new Module path.resolve(configPath)
+    configModule.filename = configModule.id
+    configModule.paths = Module._nodeModulePaths path.dirname(configModule.id)
     configModule._compile config, configPath
+    configModule.loaded = yes
     configModule.exports
 
 exports.processConfig = (opts, callback) ->


### PR DESCRIPTION
Precompiling is useful for writing **mimosa-config** (and/or profile configs) in various compile-to-JS languages.

Precompiling is performed by anonymous JavaScript function from region embedded in **mimosa-config** (and/or profile configs) and bounded by required marker lines. Marker line format is inspired by Vim modeline (but it's different).

Function region (along with marker lines) is suited to be located in comments of host language:
- marker lines are independent of its prefixes,
- prefix of start marker line is stripped from every following function source line.

Function must take one argument (string with configuration file source) and return string with compiled source.

PR contains further restrictions to general idea:
- only files without extension are searched for function region,
- start marker must be located in first 5 lines of configuration file,
- function region length is limited to 100 lines (including marker lines),
- format of marker lines:
  - start marker line: `<prefix><white>mimosa-config:<white*>{`
  - end marker line: `<prefix><white>mimosa-config:<white*>}`
  - where `<prefix>` -- any characters, `<white>` -- one space or tab character, `<white*>` -- zero or more spaces or tab characters

Example of precompile region in **mimosa-config** written in [pogoscript](http://pogoscript.org/):

``` PogoScript
// mimosa-config: {
//   function (thisConfig) { 
//     return require("pogo").compile(thisConfig);
//   }
// mimosa-config: }

exports.config = {
  watch {
    source dir "src"
  }
}
```

Example of precompile region in **mimosa-config** written in [moescript](http://moescript.github.io/):

``` MoeScript
-- mimosa-config: {
--   function (thisConfig) {
--     var compiler = require("moe/compiler"),
--         topScope = compiler.TopScope.fromSimpleMap({
--                      'exports': 'exports',
--                      'module':  'module',
--                      'require': 'require'
--                    });
--     return compiler.stdComposite(compiler.compile(thisConfig, topScope),
--                                  topScope);
--   }
-- mimosa-config: }

exports.config = [
  watch: [
    sourceDir: "src"
  ]
]
```

If configuration files without extension doesn't contain precompile region or contain empty precompile region, they will be processed as plain JavaScript files. This is also valid **mimosa-config**:

``` js
exports.config = {
  watch: {
    sourceDir: "src"
  }
}
```
