### PR TITLE
Fix for #211 - remove directories synchronously

### DIFF
--- a/lib/modules/file/clean.js
+++ b/lib/modules/file/clean.js
@@ -38,27 +38,25 @@ MimosaCleanModule = (function() {
       }
     };
     return _.sortBy(directories, 'length').reverse().forEach(function(dir) {
-      var dirPath;
+      var dirPath, err;
 
       dirPath = path.join(config.watch.compiledDir, dir);
       if (fs.existsSync(dirPath)) {
         logger.debug("Deleting directory [[ " + dirPath + " ]]");
-        return fs.rmdir(dirPath, function(err) {
-          if (err != null) {
-            if (err.code === "ENOTEMPTY") {
-              logger.info("Unable to delete directory [[ " + dirPath + " ]] because directory not empty");
-            } else {
-              logger.error("Unable to delete directory, [[ " + dirPath + " ]]");
-              logger.error(err);
-            }
+        try {
+          fs.rmdirSync(dirPath);
+          logger.success("Deleted empty directory [[ " + dirPath + " ]]");
+        } catch (_error) {
+          err = _error;
+          if (err.code === 'ENOTEMPTY') {
+            logger.info("Unable to delete directory [[ " + dirPath + " ]] because directory not empty");
           } else {
-            logger.success("Deleted empty directory [[ " + dirPath + " ]]");
+            logger.error("Unable to delete directory, [[ " + dirPath + " ]]");
+            logger.error(err);
           }
-          return done();
-        });
-      } else {
-        return done();
+        }
       }
+      return done();
     });
   };
 

--- a/src/modules/file/clean.coffee
+++ b/src/modules/file/clean.coffee
@@ -26,17 +26,15 @@ class MimosaCleanModule
       dirPath = path.join(config.watch.compiledDir, dir)
       if fs.existsSync dirPath
         logger.debug "Deleting directory [[ #{dirPath} ]]"
-        fs.rmdir dirPath, (err) ->
-          if err?
-            if err.code is "ENOTEMPTY"
-              logger.info "Unable to delete directory [[ #{dirPath} ]] because directory not empty"
-            else
-              logger.error "Unable to delete directory, [[ #{dirPath} ]]"
-              logger.error err
+        try
+          fs.rmdirSync dirPath
+          logger.success "Deleted empty directory [[ #{dirPath} ]]"
+        catch err
+          if err.code is 'ENOTEMPTY'
+            logger.info "Unable to delete directory [[ #{dirPath} ]] because directory not empty"
           else
-            logger.success "Deleted empty directory [[ #{dirPath} ]]"
-          done()
-      else
-        done()
+            logger.error "Unable to delete directory, [[ #{dirPath} ]]"
+            logger.error err
+      done()
 
 module.exports = new MimosaCleanModule()


### PR DESCRIPTION
With `fs.rmdir`, the deletion order cannot be guaranteed. It seems `fs.rmdirSync` would be the way to go, but it means wrapping the call in a try/catch. Not sure if that's what you would have in mind. And obviously, I could only test on Windows.
