### PR TITLE
fixing livescript compiler not accepting options (such as bare)

### DIFF
--- a/src/modules/compilers/javascript/livescript-compiler.coffee
+++ b/src/modules/compilers/javascript/livescript-compiler.coffee
@@ -10,11 +10,12 @@ module.exports = class LiveScriptCompiler extends JSCompiler
   @defaultExtensions = ["ls"]
 
   constructor: (config, @extensions) ->
+    @options = config.livescript
     super()
 
   compile: (file, cb) ->
     try
-      output = liveScript.compile file.inputFileText
+      output = liveScript.compile file.inputFileText, @options
     catch err
       error = err
     cb(error, output)


### PR DESCRIPTION
currently the livescript compiler has a --bare option (such as coco/coffeescript) that should be able to be turned off/on
