### PR TITLE
Changing the dynamic sourcemap declaration to one compatible with Browserify

### DIFF
--- a/lib/modules/compilers/javascript/javascript.js
+++ b/lib/modules/compilers/javascript/javascript.js
@@ -63,8 +63,8 @@ module.exports = JSCompiler = (function(_super) {
               sourceMap.sourcesContent = [file.inputFileText];
               sourceMap.file = file.outputFileName;
               base64SourceMap = new Buffer(JSON.stringify(sourceMap)).toString('base64');
-              datauri = 'data:application/json;charset=utf-8;base64,' + base64SourceMap;
-              output = "" + output + "\n/*\n//@ sourceMappingURL=" + datauri + "\n*/\n";
+              datauri = 'data:application/json;base64,' + base64SourceMap;
+              output = "" + output + "\n//@ sourceMappingURL=" + datauri + "\n";
             } else {
               whenDone += 2;
               sourceName = _this._genSourceName(config, file);

--- a/src/modules/compilers/javascript/javascript.coffee
+++ b/src/modules/compilers/javascript/javascript.coffee
@@ -46,8 +46,8 @@ module.exports = class JSCompiler extends BaseCompiler
               sourceMap.file = file.outputFileName;
 
               base64SourceMap = new Buffer(JSON.stringify(sourceMap)).toString('base64')
-              datauri = 'data:application/json;charset=utf-8;base64,' + base64SourceMap
-              output = "#{output}\n/*\n//@ sourceMappingURL=#{datauri}\n*/\n"
+              datauri = 'data:application/json;base64,' + base64SourceMap
+              output = "#{output}\n//@ sourceMappingURL=#{datauri}\n"
 
             else
               whenDone += 2


### PR DESCRIPTION
Browserify is picky about input files with source maps. This change removes the charset statement and unnecessary block comment delimiters from source map declarations appended to transpiled JS.

Ultimately, this will allow [mimosa-browserify](https://github.com/JonET/mimosa-browserify) to output source maps that map all the way back to the original source code.
