### PR TITLE
Add support for Stylus url() function.

### DIFF
--- a/lib/modules/compilers/css/stylus-compiler.js
+++ b/lib/modules/compilers/css/stylus-compiler.js
@@ -46,6 +46,9 @@ module.exports = StylusCompiler = (function(_super) {
     };
     logger.debug("Compiling Stylus file [[ " + fileName + " ]]");
     stylusSetup = this.compilerLib(text).include(path.dirname(fileName)).include(config.watch.sourceDir).set('compress', false).set('filename', fileName);
+    if (config.stylus.url) {
+      stylusSetup.define('url', this.compilerLib.url(config.stylus.url));
+    }
     if ((_ref = config.stylus.includes) != null) {
       _ref.forEach(function(inc) {
         return stylusSetup.include(inc);

--- a/src/modules/compilers/css/stylus-compiler.coffee
+++ b/src/modules/compilers/css/stylus-compiler.coffee
@@ -38,6 +38,9 @@ module.exports = class StylusCompiler extends AbstractCssCompiler
       #.set('linenos', not config.isOptimize and not config.isBuild)
       .set('filename', fileName)
 
+    if config.stylus.url
+      stylusSetup.define 'url', @compilerLib.url config.stylus.url
+
     config.stylus.includes?.forEach (inc) ->
       stylusSetup.include inc
 


### PR DESCRIPTION
Add support for Stylus url() function. Options can be set in mimosa-config, e.g.:

``` coffeescript
stylus:
  url:
    limit: 40000
```

More info on http://learnboost.github.io/stylus/docs/functions.url.html.
