### PR TITLE
let css compiler declare multi-import split regex

### DIFF
--- a/lib/modules/compilers/css.js
+++ b/lib/modules/compilers/css.js
@@ -225,20 +225,29 @@ module.exports = CSSCompiler = (function() {
   };
 
   CSSCompiler.prototype.__importsForFile = function(baseFile, file, allFiles) {
-    var anImport, fullImportFilePath, hash, importPath, imports, includeFile, includeFiles, _i, _len, _results,
+    var anImport, fullImportFilePath, hash, importMatches, importPath, imports, includeFile, includeFiles, _i, _j, _len, _len1, _results,
       _this = this;
     if (fs.existsSync(file)) {
-      imports = fs.readFileSync(file, 'utf8').match(this.compiler.importRegex);
+      importMatches = fs.readFileSync(file, 'utf8').match(this.compiler.importRegex);
     }
-    if (imports == null) {
+    if (importMatches == null) {
       return;
     }
-    logger.debug("Imports for file [[ " + file + " ]]: " + imports);
-    _results = [];
-    for (_i = 0, _len = imports.length; _i < _len; _i++) {
-      anImport = imports[_i];
+    logger.debug("Imports for file [[ " + file + " ]]: " + importMatches);
+    imports = [];
+    for (_i = 0, _len = importMatches.length; _i < _len; _i++) {
+      anImport = importMatches[_i];
       this.compiler.importRegex.lastIndex = 0;
-      importPath = this.compiler.importRegex.exec(anImport)[1];
+      anImport = this.compiler.importRegex.exec(anImport)[1];
+      if (this.compiler.importSplitRegex) {
+        imports.push.apply(imports, anImport.split(this.compiler.importSplitRegex));
+      } else {
+        imports.push(anImport);
+      }
+    }
+    _results = [];
+    for (_j = 0, _len1 = imports.length; _j < _len1; _j++) {
+      importPath = imports[_j];
       fullImportFilePath = this.compiler.getImportFilePath(file, importPath);
       includeFiles = path.extname(fullImportFilePath) === ".css" && this.compiler.canFullyImportCSS ? [fullImportFilePath] : allFiles.filter(function(f) {
         if (!_this.compiler.partialKeepsExtension) {
@@ -247,10 +256,10 @@ module.exports = CSSCompiler = (function() {
         return f.slice(-fullImportFilePath.length) === fullImportFilePath;
       });
       _results.push((function() {
-        var _j, _len1, _results1;
+        var _k, _len2, _results1;
         _results1 = [];
-        for (_j = 0, _len1 = includeFiles.length; _j < _len1; _j++) {
-          includeFile = includeFiles[_j];
+        for (_k = 0, _len2 = includeFiles.length; _k < _len2; _k++) {
+          includeFile = includeFiles[_k];
           hash = this.includeToBaseHash[includeFile];
           if (hash != null) {
             logger.debug("Adding base file [[ " + baseFile + " ]] to list of base files for include [[ " + includeFile + " ]]");

--- a/src/modules/compilers/css.coffee
+++ b/src/modules/compilers/css.coffee
@@ -179,16 +179,22 @@ module.exports = class CSSCompiler
   # those imports until entire tree is built
   __importsForFile: (baseFile, file, allFiles) ->
     if fs.existsSync(file)
-      imports = fs.readFileSync(file, 'utf8').match(@compiler.importRegex)
+      importMatches = fs.readFileSync(file, 'utf8').match(@compiler.importRegex)
 
-    return unless imports?
+    return unless importMatches?
 
-    logger.debug "Imports for file [[ #{file} ]]: #{imports}"
+    logger.debug "Imports for file [[ #{file} ]]: #{importMatches}"
 
-    for anImport in imports
-
+    imports = []
+    for anImport in importMatches
       @compiler.importRegex.lastIndex = 0
-      importPath = @compiler.importRegex.exec(anImport)[1]
+      anImport = @compiler.importRegex.exec(anImport)[1]
+      if @compiler.importSplitRegex
+        imports.push.apply(imports, anImport.split(@compiler.importSplitRegex))
+      else
+        imports.push(anImport)
+    for importPath in imports
+
       fullImportFilePath = @compiler.getImportFilePath(file, importPath)
 
       includeFiles = if path.extname(fullImportFilePath) is ".css" and @compiler.canFullyImportCSS


### PR DESCRIPTION
This lets a css compiler declare an "importSplitRegex" for handling cases (like Sass) where a single import can declare multiple files to be imported.
