### PR TITLE
Update chokidar dependency to fix sub dependency problems.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ansi-color": "0.2.1",
     "wrench": "1.5.8",
     "commander": "1.3.2",
-    "chokidar": "0.12.6",
+    "chokidar": "1.7.0",
     "request": "2.33.0",
     "logmimosa": "1.0.4",
     "skelmimosa": "1.3.0",


### PR DESCRIPTION
Chokidar v0.12.6 depends on fsevents 0.38, which causes Node 8.5.0 to fail an assertion and die with the message

```
# Fatal error in ../deps/v8/src/api.cc, line 1253
# Check failed: !value_obj->IsJSReceiver() || value_obj->IsTemplateInfo().
```

The bug has long since been fixed; chokidar version 1.7.0 has an optional dependency of fsevents 1.0.0 or later.
